### PR TITLE
Feature/tc 62 modify roles and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,26 +27,26 @@
 # Usage
 ## 1. Create MSP, Genesis Block, Channel TX with Inventory File
 ```
-ansible-playbook ./example/build-playbook.yml
+ansible-playbook ./example/build-playbook.yml --extra-vars @vars/builder/2org2peer_3raft.yml
 ```
 
 ## 2. Install Fabric, Fabric-CA
 ```
-ansible-playbook -i ./example/2org2peer_3raft/inventory.yaml ./example/fabric-install-playbook.yml
+ansible-playbook -i ./example/2org2peer_3raft/inventory.yaml -K ./example/fabric-install-playbook.yml
 ```
 ## 3. Set Hostfile, Configure & Start Fabric Network
 ```
-ansible-playbook -i ./example/2org2peer_3raft/inventory.yaml ./example/fabric-config-playbook.yml
+ansible-playbook -i ./example/2org2peer_3raft/inventory.yaml -K ./example/fabric-config-playbook.yml
 ```
 ## 4. Install nvm, node, caliper etc..
 ```
-ansible-playbook -i ./example/2org2peer_3raft/inventory.yaml ./example/caliper-install-playbook.yml
+ansible-playbook -i ./example/2org2peer_3raft/inventory.yaml -K ./example/caliper-install-playbook.yml
 ```
 ## 5. Set Hostfile, Configure & Setup Caliper, Setup Network Manage Scripts
 ```
-ansible-playbook -i ./example/2org2peer_3raft/inventory.yaml ./example/caliper-config-playbook.yml
+ansible-playbook -i ./example/2org2peer_3raft/inventory.yaml -K ./example/caliper-config-playbook.yml --extra-vars @vars/builder/2org2peer_3raft.yml
 ```
 ## 6. Create Channel, Install Chaincode, Run Caliper Benchmarks
 ```
-ansible-playbook -i ./example/2org2peer_3raft/inventory.yaml ./example/caliper-run-playbook.yml
+ansible-playbook -i ./example/2org2peer_3raft/inventory.yaml -K ./example/caliper-run-playbook.yml --extra-vars @vars/caliper/run-sample.yml
 ```

--- a/roles/orderer/defaults/main.yml
+++ b/roles/orderer/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # defaults file for orderer
 ledger_path: /var/hyperledger/orderer/production
+install_fabric_repo_name: "fabric"

--- a/roles/peer/defaults/main.yml
+++ b/roles/peer/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # defaults file for peer
 ledger_path: /var/hyperledger/peer/production
+install_fabric_repo_name: "fabric"


### PR DESCRIPTION
### 이슈 내용
  https://themedium.atlassian.net/browse/TC-62?atlOrigin=eyJpIjoiMjJmYmYwZTIxYTEzNDFkYmE3NGEzMTM1ZmEwMDRlMTIiLCJwIjoiaiJ9

### 변경 이유
- peer, orderer role 에서 `install_fabric_repo_name` 변수 없이 task name에 사용
- README.md Usage의 커멘드라인에 외부 변수와 -K 옵션 미기재

### 변경 사항
- default/main 파일에 `install_fabric_repo_name` 변수 추가
- ansible-playbook `--extra-vars` 옵션과 `-K` 옵션을 추가하여 커맨드라인 수정 