### PR TITLE
[TD-16] handle with multiple anchor peers / without anchor peer in single org

### DIFF
--- a/roles/builder/tasks/build-transactions.yml
+++ b/roles/builder/tasks/build-transactions.yml
@@ -18,9 +18,9 @@
   args:
     chdir: "{{ playbook_dir }}/{{ bld_msp_config_name }}"
 
-- name: generate anchorpeer update tx
-  shell: bin/configtxgen -profile SampleProfile -outputAnchorPeersUpdate {{ item.name | lower }}-anchor.tx -channelID mychannel -asOrg {{ item.name }}
-  args:
-    chdir: "{{ playbook_dir }}/{{ bld_msp_config_name }}"
+- name: include generate anchor peer update tx
+  include_tasks: "inner-anchor-update.yml"
   with_items:
     - "{{ bld_peer_orgs }}"
+  loop_control:
+    loop_var: org

--- a/roles/builder/tasks/inner-anchor-update.yml
+++ b/roles/builder/tasks/inner-anchor-update.yml
@@ -1,0 +1,15 @@
+- name: "inner-anchor-update"
+  block: 
+    - name: generate anchorpeer update tx
+      shell: bin/configtxgen -profile SampleProfile -outputAnchorPeersUpdate {{ org.name | lower }}-anchor.tx -channelID mychannel -asOrg {{ org.name }}
+      args:
+        chdir: "{{ playbook_dir }}/{{ bld_msp_config_name }}"
+      register: res
+      with_items:
+        - "{{ org.peers }}"
+      loop_control:
+        loop_var: peer
+      when: 
+        - peer.anchor == true 
+        - not (res.changed|d(false))
+      


### PR DESCRIPTION
bld_peer_orgs에 선언된 peer 조직에서 anchor 값이 true로 설정된 peer가 없으면 
builder role로 생성되는 configtx.yaml에 해당 peer 조직의 AnchorPeers값이 설정되지 않습니다.

configtx.yaml에 peer 조직의 AnchorPeers값이 없는 상태에서
roles/builder/tasks/build-transactions.yml의 generate anchorpeer update tx task를 실행하게 된다면
AnchorPeer가 정의되지 않은 상태에서 anchor peer update transaction 파일을 생성하려 하기 때문에 에러가 발생합니다.

따라서 bld_peer_orgs의 특정 조직에 anchor 프로퍼티가 true인 peer가 하나도 없을 경우
anchor peer update transaction 파일을 생성하지 않도록 변경했습니다.

또한  bld_peer_orgs의 특정 조직에 anchor 프로퍼티가 true인 peer가 여러개일 경우에는
anchor peer update transaction 파일을 한번만 생성하도록 변경했습니다.