### PR TITLE
[TD-25] remove tty option

### DIFF
--- a/ansible-playbook.sh
+++ b/ansible-playbook.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-docker run -it -v "${PWD}":/work -v ~/.ansible/roles:/root/.ansible/roles -v ~/.ssh:/root/.ssh:ro \
+docker run -i -v "${PWD}":/work -v ~/.ansible/roles:/root/.ansible/roles -v ~/.ssh:/root/.ssh:ro \
     --env PY_COLORS='1' \
     --env ANSIBLE_FORCE_COLOR='1' \
     --rm sukill/ansible:latest ansible-playbook $@


### PR DESCRIPTION
aws ec2 instance를 Initialize 하는 과정에서 ansible-playbook.sh를 실행시키면
아래와 같이 input device가 tty가 아니라는 메시지를 확인할 수 있습니다.

./ansible-playbook.sh ./example/build-playbook.yml --extra-vars @vars/builder/builder_config.yml
the input device is not a TTY

-t 옵션을 제거합니다.