### PR TITLE
[TD-31] add condition when peer.anchor is defined

### DIFF
--- a/roles/builder/tasks/inner-anchor-update.yml
+++ b/roles/builder/tasks/inner-anchor-update.yml
@@ -10,6 +10,7 @@
       loop_control:
         loop_var: peer
       when: 
+        - peer.anchor is defined
         - peer.anchor == true 
         - not (res.changed|d(false))
       


### PR DESCRIPTION
builder role의 "generate anchorpeer update tx" task에서 peer에 anchor attribute가 없으면 에러가 발생하는 현상을 발견하였습니다.

when 조건에 peer.anchor가 정의되었을 경우로 조건을 주어서 attribute가 있을 때만 로직을 타도록 했습니다.