### PR TITLE
Bugfix/td 30 not copy anchor update tx not update channel without anchorpeer

### DIFF
--- a/roles/builder/tasks/inner-anchor-update.yml
+++ b/roles/builder/tasks/inner-anchor-update.yml
@@ -13,4 +13,6 @@
         - peer.anchor is defined
         - peer.anchor == true 
         - not (res.changed|d(false))
-      
+    - name: reset register
+      set_fact:
+        res: ""

--- a/roles/caliper/tasks/configure/networks-config/_copy_network_tx.yml
+++ b/roles/caliper/tasks/configure/networks-config/_copy_network_tx.yml
@@ -9,10 +9,8 @@
     src: "{{ playbook_dir }}/{{ bld_msp_config_name }}/mychannel.tx"
     dest: "{{ caliper_workspace | mandatory }}/networks/"
 
-- name: Copy anchorpeer update transaction
-  copy:
-    src: "{{ playbook_dir }}/{{ bld_msp_config_name }}/{{ org.name | lower }}-anchor.tx"
-    dest: "{{ caliper_workspace | mandatory }}/networks/"
+- name: include copy anchorpeer update transaction
+  include_tasks: "inner_anchor_update.yml"
   with_items:
     - "{{ bld_peer_orgs }}"
   loop_control:

--- a/roles/caliper/tasks/configure/networks-config/inner_anchor_update.yml
+++ b/roles/caliper/tasks/configure/networks-config/inner_anchor_update.yml
@@ -1,0 +1,17 @@
+- name: Copy anchorpeer update transaction
+  copy:
+    src: "{{ playbook_dir }}/{{ bld_msp_config_name }}/{{ org.name | lower }}-anchor.tx"
+    dest: "{{ caliper_workspace | mandatory }}/networks/"
+  register: res
+  with_items:
+    - "{{ org.peers }}"
+  loop_control:
+    loop_var: peer
+  when: 
+    - peer.anchor is defined
+    - peer.anchor == true 
+    - not (res.changed|d(false))
+    
+- name: reset register
+  set_fact:
+    res: ""

--- a/roles/caliper/templates/setup-channel.sh.jinja2
+++ b/roles/caliper/templates/setup-channel.sh.jinja2
@@ -4,6 +4,7 @@
 export CORE_PEER_TLS_ENABLED=true
 export CHANNEL_NAME=mychannel
 {% for org in bld_peer_orgs %}
+{% set anchor_updated = false %}
 {% for peer in org.peers %}
 
 export CORE_PEER_ID={{ peer.host_name }}.{{ org.domain }}
@@ -29,12 +30,13 @@ peer channel join --tls \
     -o {{ orderer.address }}:{{ orderer.port }} --ordererTLSHostnameOverride {{ orderer.host_name }}.{{ ordererorg.domain }} \
     --cafile networks/crypto-config/ordererOrganizations/{{ ordererorg.domain }}/users/Admin@{{ ordererorg.domain }}/tls/ca.crt
 
-{% if peer == org.peers[0] %} 
+{% if anchor_updated == false and peer.anchor is defined and peer.anchor == true %}
+{% set anchor_updated = true %}
 peer channel update -c $CHANNEL_NAME --tls \
     -f networks/{{ org.name | lower }}-anchor.tx \
     -o {{ orderer.address }}:{{ orderer.port }}  --ordererTLSHostnameOverride {{ orderer.host_name }}.{{ ordererorg.domain }} \
     --cafile networks/crypto-config/ordererOrganizations/{{ ordererorg.domain }}/users/Admin@{{ ordererorg.domain }}/tls/ca.crt
-    {% endif %}
+{% endif %}
 {% endfor %}
 {% endfor %}
 


### PR DESCRIPTION
AS-IS

1. bld_peer_orgs를 순회하여 조직 마다 [조직명]-anchor.tx 파일을 remote 에 copy 합니다.
2. setup-channel.sh 스크립트에서 org의 가장 첫 번째 peer의 msp를 사용하여 [조직명]-anchor.tx 파일로 channel update 트랜잭션을 submit 합니다.

TO-BE

1. org에 anchor peer가 존재하지 않을 수 있기 때문에 anchor peer가 있는 경우에만 [조직명]-anchor.tx를 remote에 copy 합니다.
2. setup-channel.sh 스크립트에서 org에 anchor peer가 있는 경우에만 channel update를 진행합니다.
두 가지 모두 anchor peer가 여러 개일 경우 조직 당 최초 한 번만 수행합니다.