### PR TITLE
 In golang, copy collection-config.json if collecion_exist is true.

### DIFF
--- a/roles/caliper/tasks/configure/chaincode/get_dependency/golang.yml
+++ b/roles/caliper/tasks/configure/chaincode/get_dependency/golang.yml
@@ -12,3 +12,9 @@
   shell:
     cmd: /bin/bash -ic 'go mod vendor'
     chdir: "{{ caliper_workspace }}/src/{{ chaincode.name }}/golang"
+
+- name: Setup collection config
+  template:
+    src: "collection-config.yaml.jinja2"
+    dest: "{{ caliper_workspace }}/src/{{ chaincode.name }}/collection-config.json"
+  when: chaincode.collection_exists


### PR DESCRIPTION
caliper-run 수행시   install_audit.sh 에서 collection-config.json을 찾지 못하여 error가 발생한 부분 수정하였습니다. nodejs에서는 config file  copy 부분이 있었는데 golang에서는 누락되어 있었습니다.