### PR TITLE
Fix warnings on running 'ansible-playbook ./example/build-playbook.yml'

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -13,7 +13,7 @@
 [defaults]
 inventory        = hosts.yaml
 
-command_warnings = False
+deprecation_warnings = False
 #library         = ~/.ansible/plugins/modules:/usr/share/ansible/plugins/modules
 #module_utils    = ~/.ansible/plugins/module_utils:/usr/share/ansible/plugins/module_utils
 #remote_tmp      = ~/.ansible/tmp

--- a/hosts.yaml
+++ b/hosts.yaml
@@ -1,0 +1,7 @@
+all:
+  hosts:
+    localhost:
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ansible_playbook_python}}"
+

--- a/roles/builder/tasks/build-ccp.yml
+++ b/roles/builder/tasks/build-ccp.yml
@@ -3,8 +3,10 @@
     src: "connection_org.yaml.jinja"
     dest: "{{ playbook_dir }}/{{ bld_msp_config_name }}/connection_{{ org.name.lower() }}.yaml"
   vars:
-    org: "{{ item }}"
+    org: "{{ org_item }}"
     tls_path: "{{ playbook_dir }}/{{ bld_msp_config_name }}/crypto-config/peerOrganizations/{{ org.name.lower() }}.com/tlsca/tlsca.{{ org.name.lower() }}.com-cert.pem"
     tls_pem: "{{ lookup('file', tls_path) }}"
   with_items:
     - "{{ bld_peer_orgs }}"
+  loop_control:
+    loop_var: org_item

--- a/roles/builder/templates/inventory.jinja2
+++ b/roles/builder/templates/inventory.jinja2
@@ -55,11 +55,11 @@ all:
         calipers:
             hosts:
         {%- if bld_caliper.type == "local" %}
-            {% filter indent(width=14, first=True) %}
+            {% filter indent(width=14, first=False) %}
             {% include './templates/inventory_caliper_local.jinja2'  %}
             {% endfilter %}
         {%- elif bld_caliper.type == "remote" %}
-            {% filter indent(width=14, first=True) %}
+            {% filter indent(width=14, first=False) %}
             {% include './templates/inventory_caliper_remote.jinja2'  %}
             {% endfilter %}
         {% endif %}


### PR DESCRIPTION
1. build-playbook.yaml 에 대해 실행할 때 나타나는 다음 warning을 고칩니다.
2. 결과로 생성되는 inventory.yaml 안의 trailing whitespace를 없앱니다.

```
[DEPRECATION WARNING]: COMMAND_WARNINGS option, the command warnings feature is being removed. This feature will be removed from ansible-core in version 2.14. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

```
[WARNING]: Unable to parse /Users/medium/src/justin-themedium/fabric-softener/hosts.yaml as an inventory source
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
```

```
TASK [builder : set connection_orgs.yaml] ***************************************************************************************
[WARNING]: The loop variable 'item' is already in use. You should set the `loop_var` value in the `loop_control` option for the task to something else to avoid variable collisions and unexpected behavior.
```
