### PR TITLE
Set path_item as loop_var for copying mspconfig

### DIFF
--- a/roles/fabric-ca/tasks/configure.yml
+++ b/roles/fabric-ca/tasks/configure.yml
@@ -35,10 +35,12 @@
 
 - name: Copy mspconfig
   copy:
-        src: "{{ playbook_dir }}/{{ item.path }}"
-        dest: "{{ fabric_ca_home | mandatory }}/{{ item.path }}"
+        src: "{{ playbook_dir }}/{{ path_item.path }}"
+        dest: "{{ fabric_ca_home | mandatory }}/{{ path_item.path }}"
   with_items:
     - { path: "{{ ca_private_key }}" }
     - { path: "{{ ca_certificate }}" }
     - { path: "{{ ca_tls_key }}" }
     - { path: "{{ ca_tls_cert }}" }
+  loop_control:
+    loop_var: path_item

--- a/roles/fabric-ca/tasks/configure/msp.yml
+++ b/roles/fabric-ca/tasks/configure/msp.yml
@@ -12,10 +12,12 @@
 
 - name: Copy mspconfig
   copy:
-        src: "{{ playbook_dir }}/{{ item.path }}"
-        dest: "{{ fabric_ca_home | mandatory }}/{{ item.path }}"
+        src: "{{ playbook_dir }}/{{ path_item.path }}"
+        dest: "{{ fabric_ca_home | mandatory }}/{{ path_item.path }}"
   with_items:
     - { path: "{{ ca_private_key }}" }
     - { path: "{{ ca_certificate }}" }
     - { path: "{{ ca_tls_key }}" }
     - { path: "{{ ca_tls_cert }}" }
+  loop_control:
+    loop_var: path_item

--- a/roles/orderer/tasks/configure.yml
+++ b/roles/orderer/tasks/configure.yml
@@ -22,11 +22,13 @@
 
 - name: Copy mspconfig
   copy:
-    src: "{{ playbook_dir }}/{{ '/'.join(msp_dir.split('/')[:-1]) }}/{{ item.path }}"
+    src: "{{ playbook_dir }}/{{ '/'.join(msp_dir.split('/')[:-1]) }}/{{ path_item.path }}"
     dest: "{{ fabric_cfg_path | mandatory }}/{{ bld_msp_config_name }}/"
   with_items:
     - { path: "msp" }
     - { path: "tls" }
+  loop_control:
+    loop_var: path_item
 
 - name: Setup genesis block
   copy:

--- a/roles/orderer/tasks/configure/msp.yml
+++ b/roles/orderer/tasks/configure/msp.yml
@@ -6,8 +6,10 @@
 
 - name: Copy mspconfig
   copy:
-    src: "{{ playbook_dir }}/{{ '/'.join(msp_dir.split('/')[:-1]) }}/{{ item.path }}"
+    src: "{{ playbook_dir }}/{{ '/'.join(msp_dir.split('/')[:-1]) }}/{{ path_item.path }}"
     dest: "{{ fabric_cfg_path | mandatory }}/{{ bld_msp_config_name }}/"
   with_items:
     - { path: "msp" }
     - { path: "tls" }
+  loop_control:
+    loop_var: path_item

--- a/roles/peer/tasks/configure/msp.yml
+++ b/roles/peer/tasks/configure/msp.yml
@@ -6,8 +6,10 @@
 
 - name: Copy mspconfig
   copy:
-        src: "{{ playbook_dir }}/{{ '/'.join(msp_dir.split('/')[:-1]) }}/{{ item.path }}"
+        src: "{{ playbook_dir }}/{{ '/'.join(msp_dir.split('/')[:-1]) }}/{{ path_item.path }}"
         dest: "{{ fabric_cfg_path | mandatory }}/{{bld_msp_config_name}}/"
   with_items:
     - { path: "msp" }
     - { path: "tls" }
+  loop_control:
+    loop_var: path_item


### PR DESCRIPTION
Fix the below warning:
[WARNING]: The loop variable 'item' is already in use. You should set the `loop_var` value in the `loop_control` option for the task to something else to avoid variable collisions and unexpected behavior.

Signed-off-by: Justin Yang <justin.yang@themedium.io>