### PR TITLE
[TD-12] Handling nvm installation if there is no curl on the environment

### DIFF
--- a/roles/caliper/tasks/install/main.yml
+++ b/roles/caliper/tasks/install/main.yml
@@ -7,8 +7,8 @@
         tasks_from: main.yml
       vars:
         install_targets:
-          - node
           - package
+          - node
           - hosts
           - fabric-v2
         install_fabric_target: peer
@@ -55,3 +55,4 @@
           - package
           - dockercompose
   when: role == "worker"
+...

--- a/roles/install/tasks/package-ubuntu.yml
+++ b/roles/install/tasks/package-ubuntu.yml
@@ -4,6 +4,7 @@
     name:
       - build-essential
       - git
+      - curl
     state: present
     update_cache: yes
     allow_unauthenticated: yes


### PR DESCRIPTION
우분투 20.04에서 curl이 없는 경우 node 설치에서 에러가 발생하는 부분을 처리하기 위함입니다.

1. package-ubuntu installation 과정에 curl을 설치합니다.
2. package 설치를 끝낸 후 node 설치를 진행하여 curl 이 있는 환경에서 curl로 설치합니다. 기존에는 node 설치 먼저 진행한 후 package 설치가 진행되었습니다.
