### PR TITLE
[TD-13] Fix the installation of auction chaincode

### DIFF
--- a/roles/caliper/defaults/main.yml
+++ b/roles/caliper/defaults/main.yml
@@ -27,4 +27,4 @@ caliper_config_chaincodes:
       - smallbankOperations
   - name: auction
     lang: golang
-    collection_config_needed: true
+    collection_config_needed: false

--- a/roles/caliper/defaults/main.yml
+++ b/roles/caliper/defaults/main.yml
@@ -8,23 +8,23 @@ caliper_config_worker_num_each: 1
 caliper_config_chaincodes:
   - name: fixed-asset
     lang: node
-    collection_exists: true
+    collection_config_needed: true
     callbacks:
       - create-asset
       - create-private-asset
   - name: simple
     lang: golang
-    collection_exists: false
+    collection_config_needed: false
     callbacks:
       - open
       - query
       - transfer
   - name: smallbank
     lang: golang
-    collection_exists: false
+    collection_config_needed: false
     callbacks:
       - query
       - smallbankOperations
   - name: auction
     lang: golang
-    collection_exists: true
+    collection_config_needed: true

--- a/roles/caliper/files/auction/golang/smartContract.go
+++ b/roles/caliper/files/auction/golang/smartContract.go
@@ -8,6 +8,7 @@ import (
 	"log"
 
 	"github.com/hyperledger/fabric-contract-api-go/contractapi"
+	auction "github.com/hyperledger/fabric-samples/auction/chaincode-go/smart-contract"
 )
 
 func main() {

--- a/roles/caliper/tasks/configure/chaincode/get_dependency/node.yml
+++ b/roles/caliper/tasks/configure/chaincode/get_dependency/node.yml
@@ -7,4 +7,4 @@
   template:
     src: "collection-config.yaml.jinja2"
     dest: "{{ caliper_workspace }}/src/{{ chaincode.name }}/collection-config.json"
-  when: chaincode.collection_exists
+  when: chaincode.collection_config_needed

--- a/roles/caliper/templates/setup-chaincode.sh.jinja2
+++ b/roles/caliper/templates/setup-chaincode.sh.jinja2
@@ -39,7 +39,7 @@ peer lifecycle chaincode approveformyorg -o {{ orderer.host_name }}.{{ ordereror
         --cafile networks/crypto-config/ordererOrganizations/{{ ordererorg.domain }}/users/Admin@{{ ordererorg.domain }}/tls/ca.crt \
         --signature-policy "OR({{ msp_ids|join(',') }})" --channelID mychannel --name {{ chaincode.name }} --version v1.0.0 \
         --package-id $PKG_ID \
-{% if chaincode.collection_exists %}
+{% if chaincode.collection_config_needed %}
         --collections-config src/{{ chaincode.name }}/collection-config.json \
 {% endif %}
         --sequence 1
@@ -56,7 +56,7 @@ peer lifecycle chaincode commit -o {{ orderer.host_name }}.{{ ordererorg.domain 
         --peerAddresses {{ peer.host_name }}.{{ org.domain }}:{{ peer.port }} \
         --tlsRootCertFiles networks/crypto-config/peerOrganizations/{{ org.domain }}/users/Admin@{{ org.domain }}/tls/ca.crt \
 {% endfor %}
-{% if chaincode.collection_exists %}
+{% if chaincode.collection_config_needed %}
         --collections-config src/{{ chaincode.name }}/collection-config.json \
 {% endif %}
         --sequence 1


### PR DESCRIPTION
auction chaincode 설치 실패 해결

1. collection_exists 이름 대신 명확한 의미 전달을 위해 collection_config_needed 이름 사용

> 다만 collection_exists라는 변수명이 아예 collection을 사용하지 않는 것으로 오해의 소지를 제공할 수 있기 때문에 적절한 변수명으로 바꾸는 것이 어떨지 제안드립니다. (explicit_collection_exists 어떠신가요?)

> Cena가 제안했던 explicit_collection_exists 이름은 collection_config_needed 는 어떨까요?

2. auction chaincode의 collection_config_needed를 false로 셋팅.
> auction 체인코드에서는 private data collection이 사용되긴 하지만 해당 collection은 implicit private data collection으로 explicitly 하게 정의하지 않는 것이기 때문에 따로 collection-config 파일이 필요하지 않기 때문입니다.
> 그래서 단순히 default 값으로 auction의 collection_exists를 false로 바꾸면 해결할 수 있을 것 같습니다.

3. chaincode 빌드 문제 있는 부분을 수정(roles/caliper/files/auction/golang/smartContract.go)
 