### PR TITLE
[TD-34] use host network

### DIFF
--- a/ansible-playbook.sh
+++ b/ansible-playbook.sh
@@ -2,4 +2,5 @@
 docker run -i -v "${PWD}":/work -v ~/.ansible/roles:/root/.ansible/roles -v ~/.ssh:/root/.ssh:ro \
     --env PY_COLORS='1' \
     --env ANSIBLE_FORCE_COLOR='1' \
+    --network host \
     --rm sukill/ansible:latest ansible-playbook $@


### PR DESCRIPTION
ansible이 실행되는 host에 setup을 할 때 ansible-playbook.sh 스크립트를 이용할 경우
container가 host에 접속을 할 수 있도록 하기 위해서 docker 명령어 실행 시 --network host 옵션을 추가해 줍니다.
