### PR TITLE
[TD-34] handle None, not iterable caliper_config_chaincodes

### DIFF
--- a/roles/caliper/tasks/configure/chaincode/main.yml
+++ b/roles/caliper/tasks/configure/chaincode/main.yml
@@ -10,26 +10,29 @@
     recurse: true
   when: role != "worker"
 
-- name: Copy chaincode source
-  include_tasks: _setup_source.yml
-  with_items: "{{ caliper_config_chaincodes }}"
-  loop_control:
-    loop_var: chaincode
-  when: role != "worker"
+- name: Chaincode related setup
+  block:
+    - name: Copy chaincode source
+      include_tasks: _setup_source.yml
+      with_items: "{{ caliper_config_chaincodes }}"
+      loop_control:
+        loop_var: chaincode
+      when: role != "worker"
 
-- name: Setup benchmark callback
-  include_tasks: _setup_callback.yml
-  with_items: "{{ caliper_config_chaincodes }}"
-  loop_control:
-    loop_var: chaincode
-  when: chaincode.callbacks is defined
+    - name: Setup benchmark callback
+      include_tasks: _setup_callback.yml
+      with_items: "{{ caliper_config_chaincodes }}"
+      loop_control:
+        loop_var: chaincode
+      when: chaincode.callbacks is defined
 
-- name: Setup chaincode install script
-  include_tasks: _setup_script.yml
-  with_items: "{{ caliper_config_chaincodes }}"
-  loop_control:
-    loop_var: chaincode
-  when: role != "worker"
-
-
-
+    - name: Setup chaincode install script
+      include_tasks: _setup_script.yml
+      with_items: "{{ caliper_config_chaincodes }}"
+      loop_control:
+        loop_var: chaincode
+      when: role != "worker"
+  when: 
+    - caliper_config_chaincodes != None
+    - caliper_config_chaincodes is iterable
+    - caliper_config_chaincodes | length > 0

--- a/roles/caliper/templates/network-config.yaml.jinja2
+++ b/roles/caliper/templates/network-config.yaml.jinja2
@@ -61,12 +61,14 @@ channels:
         eventSource: true
 {% endfor %}
 {% endfor %}
+{% if caliper_config_chaincodes != None and caliper_config_chaincodes is iterable and caliper_config_chaincodes | length > 0 %}
     chaincodes:
 {% for cc in caliper_config_chaincodes %}
     - id: {{ cc.name }}
       version: v1.0.0
       language: {{ cc.lang }}
 {% endfor %}
+{% endif %}
 
 organizations:
 {% for org in bld_peer_orgs %}


### PR DESCRIPTION
fabric-softener를 통해서 chaincode를 설치하기를 원하지 않을 경우
caliper_config_chaincodes에 다른 값을 할당함으로써 목적을 달성할 수 있습니다.
이 때 caliper_config_chaincodes에 None 값이나 iterable 하지 않은 값이 들어올 수 있기 때문에 각 상황에 대응할 수 있도록 합니다.