### PR TITLE
[TD-37] set module path when go mod init for chaincode

### DIFF
--- a/roles/caliper/defaults/main.yml
+++ b/roles/caliper/defaults/main.yml
@@ -7,12 +7,14 @@ caliper_config_worker_num_each: 1
 
 caliper_config_chaincodes:
   - name: fixed-asset
+    module_path: fixed-asset
     lang: node
     collection_config_needed: true
     callbacks:
       - create-asset
       - create-private-asset
   - name: simple
+    module_path: simple
     lang: golang
     collection_config_needed: false
     callbacks:
@@ -20,11 +22,13 @@ caliper_config_chaincodes:
       - query
       - transfer
   - name: smallbank
+    module_path: smallbank
     lang: golang
     collection_config_needed: false
     callbacks:
       - query
       - smallbankOperations
   - name: auction
+    module_path: auction
     lang: golang
     collection_config_needed: false

--- a/roles/caliper/tasks/configure/chaincode/get_dependency/golang.yml
+++ b/roles/caliper/tasks/configure/chaincode/get_dependency/golang.yml
@@ -1,6 +1,6 @@
 - name: go mod init
   shell:
-    cmd: /bin/bash -ic 'go mod init {{ chaincode.name }}'
+    cmd: /bin/bash -ic 'go mod init {{ chaincode.module_path }}'
     chdir: "{{ caliper_workspace }}/src/{{ chaincode.name }}/golang"
 
 - name: go mod tidy


### PR DESCRIPTION
fabric-softener를 이용하여 golang으로 작성된 chaincode를 설치할 때 각 chaincode의 project root에서 go mod init을 수행합니다.

이때 인자로 주어지는 module path는 현재 chaincode 이름으로 하도록 되어 있는데
module_path 변수를 추가하여 chaincode 이름과 다른 값을 module path 설정할 수 있도록 합니다.