### PR TITLE
[TD-12] Install curl first in package installation

### DIFF
--- a/roles/caliper/tasks/install/main.yml
+++ b/roles/caliper/tasks/install/main.yml
@@ -51,8 +51,8 @@
         tasks_from: main.yml
       vars:
         install_targets:
-          - node
           - package
+          - node
           - docker
           - dockercompose
   when: role == "worker"


### PR DESCRIPTION
Install curl in package first before node installation on remotes workers

Signed-off-by: Justin Yang <justin.yang@themedium.io>